### PR TITLE
Add github basic auth

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ require (
 	github.com/go-openapi/spec v0.19.5 // indirect
 	github.com/google/go-github/v29 v29.0.3
 	github.com/gorilla/mux v1.7.4
+	github.com/spf13/pflag v1.0.5
+	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	k8s.io/apiextensions-apiserver v0.17.3
 	k8s.io/apimachinery v0.17.3


### PR DESCRIPTION
Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Adds ability to provide Github [personal access token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line) to receive higher rate limits for API requests.

Ref: #13 