### PR TITLE
Add short-term analytics solution

### DIFF
--- a/deploy/doc.yaml
+++ b/deploy/doc.yaml
@@ -23,6 +23,8 @@ spec:
                 secretKeyRef:
                   name: doc-redis
                   key: endpoint
+            - name: ANALYTICS
+              value: "true"
           ports:
             - containerPort: 5000
               name: doc

--- a/template/analytics.html
+++ b/template/analytics.html
@@ -1,0 +1,10 @@
+{{define "analytics"}}
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-116820283-2"></script>
+<script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag() { dataLayer.push(arguments); }
+    gtag('js', new Date());
+
+    gtag('config', 'UA-116820283-2');
+</script>
+{{end}}

--- a/template/doc.html
+++ b/template/doc.html
@@ -4,6 +4,9 @@
 <head>
     <title>Doc</title>
     <link rel="icon" type="image/png" href="/static/favicon.ico?v=1" />
+    {{ if .Analytics}}
+    {{ template "analytics" }}
+    {{ end }}
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>

--- a/template/home.html
+++ b/template/home.html
@@ -4,6 +4,9 @@
 <head>
     <title>Doc</title>
     <link rel="icon" type="image/png" href="/static/favicon.ico?v=1" />
+    {{ if .Analytics}}
+    {{ template "analytics" }}
+    {{ end }}
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>

--- a/template/new.html
+++ b/template/new.html
@@ -4,6 +4,9 @@
 <head>
     <title>Doc</title>
     <link rel="icon" type="image/png" href="/static/favicon.ico?v=1" />
+    {{ if .Analytics}}
+    {{ template "analytics" }}
+    {{ end }}
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>

--- a/template/org.html
+++ b/template/org.html
@@ -4,6 +4,9 @@
 <head>
     <title>Doc</title>
     <link rel="icon" type="image/png" href="/static/favicon.ico?v=1" />
+    {{ if .Analytics}}
+    {{ template "analytics" }}
+    {{ end }}
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>


### PR DESCRIPTION
This enables adding analytics to `doc`. In the future we should be enable passing any GA key so that `doc` can be run with analytics at different domains by end-users.

Ref: #18 