### PR TITLE
Only set schema to storage version schema if defined

### DIFF
--- a/cmd/doc/main.go
+++ b/cmd/doc/main.go
@@ -216,12 +216,9 @@ func doc(w http.ResponseWriter, r *http.Request) {
 	if len(crd.Spec.Versions) > 1 {
 		for _, version := range crd.Spec.Versions {
 			if version.Storage == true {
-				if version.Schema == nil {
-					log.Printf("storage version has not schema")
-					fmt.Fprint(w, "Specified storage version does not have a schema.")
-					return
+				if version.Schema != nil {
+					schema = version.Schema
 				}
-				schema = version.Schema
 				break
 			}
 		}


### PR DESCRIPTION
Currently Doc fails to render CRD schemas if a CRD defines a storage version but does not set the schema on that specific version. This updates the check to only set the schema to the storage version schema if it is defined.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>