### PR TITLE
Reduce size of metadata stored for CRDs in repo

### DIFF
--- a/cmd/gitter/main.go
+++ b/cmd/gitter/main.go
@@ -203,7 +203,9 @@ func getCRDsFromTag(repo string, dir string, tag string, hash *plumbing.Hash, w 
 		repoData.CRDs = append(repoData.CRDs, models.RepoCRD{
 			Path:     res.FileName,
 			Filename: path.Base(res.FileName),
-			CRD:      crder.CRD,
+			Group:    crder.CRD.Spec.Group,
+			Version:  crder.CRD.Spec.Version,
+			Kind:     crder.CRD.Spec.Names.Kind,
 		})
 		crds["github.com"+"/"+repo+"/"+res.FileName+"@"+tag] = bytes
 	}
@@ -245,7 +247,9 @@ func getCRDsFromMaster(repo string, dir string, w *git.Worktree) (*models.Repo, 
 		repoData.CRDs = append(repoData.CRDs, models.RepoCRD{
 			Path:     res.FileName,
 			Filename: path.Base(res.FileName),
-			CRD:      crder.CRD,
+			Group:    crder.CRD.Spec.Group,
+			Version:  crder.CRD.Spec.Version,
+			Kind:     crder.CRD.Spec.Names.Kind,
 		})
 		crds["github.com"+"/"+repo+"/"+res.FileName] = bytes
 	}

--- a/pkg/models/repo.go
+++ b/pkg/models/repo.go
@@ -18,8 +18,6 @@ package models
 
 import (
 	"time"
-
-	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 )
 
 // Repo is data for a Github repo.
@@ -34,5 +32,7 @@ type Repo struct {
 type RepoCRD struct {
 	Path     string
 	Filename string
-	CRD      *apiextensions.CustomResourceDefinition
+	Group    string
+	Version  string
+	Kind     string
 }

--- a/template/org.html
+++ b/template/org.html
@@ -35,7 +35,7 @@
         <div class="table-responsive">
             <table class="table">
                 {{ range $i, $crd := .CRDs }}
-                <tr><td><a href="/github.com/{{ $.Repo }}/{{ $crd.Path }}{{ $.At }}{{ $.Tag }}">{{ $crd.CRD.Spec.Names.Kind }}</a></td><td>{{ $crd.CRD.Spec.Group }}/{{ $crd.CRD.Spec.Version }}</td></tr>
+                <tr><td><a href="/github.com/{{ $.Repo }}/{{ $crd.Path }}{{ $.At }}{{ $.Tag }}">{{ $crd.Kind }}</a></td><td>{{ $crd.Group }}/{{ $crd.Version }}</td></tr>
                 {{ end }}
             </table>
         </div>


### PR DESCRIPTION
The update to store GVK of CRDs in a repo caused the full CRD to be stored, which is
mostly extraneous data for the org page. This makes it such that only the CRD GVK is stored, which is the only information we care about.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>