### PR TITLE
Do not store CRDs more than once

### DIFF
--- a/cmd/doc/main.go
+++ b/cmd/doc/main.go
@@ -84,7 +84,7 @@ type orgData struct {
 	Repo       string
 	Tag        string
 	At         string
-	CRDs       []models.RepoCRD
+	CRDs       map[string]models.RepoCRD
 	Total      int
 	LastParsed string
 }

--- a/pkg/crd/crd.go
+++ b/pkg/crd/crd.go
@@ -197,3 +197,9 @@ func StripConversion() Modifier {
 		crd.Spec.Conversion = nil
 	}
 }
+
+// PrettyGVK returns a group, version, kind representation in order of
+// specificity.
+func PrettyGVK(gvk *schema.GroupVersionKind) string {
+	return fmt.Sprintf("%s/%s/%s", gvk.Group, gvk.Kind, gvk.Version)
+}

--- a/pkg/models/repo.go
+++ b/pkg/models/repo.go
@@ -25,7 +25,7 @@ type Repo struct {
 	GithubURL  string
 	Tag        string
 	LastParsed time.Time
-	CRDs       []RepoCRD
+	CRDs       map[string]RepoCRD
 }
 
 // RepoCRD is a CRD and data about its location in a repository.


### PR DESCRIPTION
Currently if a repo has the same CRD (specified by GVK) in a repo
multiple times it will be stored multiple times, distinguished by
filepath. This changes CRDs to only be stored once, with the last parsed
representation serving as the source of truth (if representations vary).
This fixes the issue of having CRDs represented multiple times for a
repo, but does not guarantee that the correct schema is being used. This
should be addressed in a future PR by introducing a config file.

Ref #64 

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>