### PR TITLE
Reset after checkout to guard against .gitignore in commit history

### DIFF
--- a/cmd/gitter/main.go
+++ b/cmd/gitter/main.go
@@ -171,6 +171,11 @@ func getCRDsFromTag(repo string, dir string, tag string, hash *plumbing.Hash, w 
 	if err != nil {
 		return nil, nil, err
 	}
+	if err := w.Reset(&git.ResetOptions{
+		Mode: git.HardReset,
+	}); err != nil {
+		return nil, nil, err
+	}
 	reg := regexp.MustCompile("kind: CustomResourceDefinition")
 	regPath := regexp.MustCompile("^.*\\.yaml")
 	g, _ := w.Grep(&git.GrepOptions{


### PR DESCRIPTION
If a file was previously included in .gitignore, checking out a tag
causes it to be staged for deletion and not included in file tree. This
updates to reset any uncommitted changes after each checkout.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>