### PR TITLE
Replace permission bits with octal notation

### DIFF
--- a/cmd/gitter/main.go
+++ b/cmd/gitter/main.go
@@ -266,6 +266,8 @@ func splitYAML(greps []git.GrepResult, dir string) map[string][][]byte {
 			log.Printf("failed to read CRD file: %s", res.FileName)
 			continue
 		}
+		// TODO(hasheddan): generalize this replacement
+		b = bytes.ReplaceAll(b, []byte("rw-rw----"), []byte("660"))
 		allCRDs[res.FileName] = bytes.Split(b, []byte("---"))
 	}
 	return allCRDs


### PR DESCRIPTION
Fixes an issue where a YAML document separator was being identified in
the permission bits for a field description, in this case fsGroup.
Temporary replacement that addresses only rw-rw---- by replacing with
660.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Fixes #86 