### PR TITLE
Add optional analytics to raw YAML endpoints

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/go-redis/redis/v7 v7.2.0
 	github.com/golang/protobuf v1.3.5 // indirect
 	github.com/google/go-cmp v0.4.0 // indirect
+	github.com/google/uuid v1.1.1
 	github.com/gorilla/mux v1.7.4
 	github.com/hashicorp/golang-lru v0.5.3 // indirect
 	github.com/imdario/mergo v0.3.7 // indirect


### PR DESCRIPTION
Adds the ability to log analytics for hits on raw YAML endpoints.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>