### PR TITLE
Fix links when viewing CRDs at tag

### DIFF
--- a/template/org.html
+++ b/template/org.html
@@ -34,7 +34,7 @@
         {
             Header: 'Kind',
             accessor: 'Kind',
-            Cell: ({ row: { original }, value }) => html`<a href=${`/github.com/${Repo}/${original.Path}/${At}/${Tag}`}>${value}</a>`
+            Cell: ({ row: { original }, value }) => html`<a href=${`/github.com/${Repo}/${original.Path}${At}${Tag}`}>${value}</a>`
         },
         {
             Header: 'Group',


### PR DESCRIPTION
Updates links to work correctly when viewing a repos CRDs at a specific
tagged version. Previously, the @ symbol and tag were being separated by
slashes, as were the links to specific fields.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Follow up to #97 