### PR TITLE
fix: array properties and some small bugs

### DIFF
--- a/static/root.css
+++ b/static/root.css
@@ -18,3 +18,7 @@
         padding-right: 1.5rem;
     }
 }
+
+body .content-wrapper {
+    padding-bottom: 2rem;
+}

--- a/template/doc.html
+++ b/template/doc.html
@@ -34,11 +34,8 @@
     });
 
     marked.setOptions({
-        highlight: (code, lang, callback) => {
-            try {
-                const result = Prism.highlight(code, Prism.languages[lang], lang);
-                callback(null, result);
-            } catch (e) { callback(e, undefined) }
+        highlight: (code, lang) => {
+            return `<pre><code class="language-${lang}">${code}</code></pre>`
         }
     })
 
@@ -50,7 +47,15 @@
     if (properties.metadata && properties.metadata.Type == "object") delete properties.metadata;
 
     function getDescription(schema) {
-        return DOMPurify.sanitize(marked.parseInline(schema.Description));
+        let desc = schema.Description;
+        if (schema.Enum) {
+            desc += '\n' + `
+\`\`\`yaml
+# valid values
+${schema.Enum.map(e => `- '${e}'`).join('\n')}
+\`\`\``.trim()
+        }
+        return DOMPurify.sanitize(marked(desc));
     }
 
     function CRD() {
@@ -79,16 +84,32 @@
     }
 
     function SchemaPart({ key, property, parent, parentSlug }) {
-        const [props, propKeys, required] = useMemo(() => {
-            const props = property.Properties || {};
-            const propKeys = Object.keys(props);
+        const [props, propKeys, required, type, schema] = useMemo(() => {
+            let schema = property;
+            let props = property.Properties || {};
+
+            let type = property.Type;
+            if (type === 'array') {
+                const itemsSchema = property.Items.Schema;
+                if (itemsSchema.Type !== 'object') {
+                    type = `[]${itemsSchema.Type}`;
+                } else {
+                    schema = itemsSchema;
+                    props = itemsSchema.Properties;
+                }
+            }
+            let propKeys = Object.keys(props);
 
             let required = false;
             if (parent && parent.Required && parent.Required.includes(key)) {
                 required = true;
             }
-            return [props, propKeys, required]
+            return [props, propKeys, required, type, schema]
         }, [parent, property]);
+
+        if (schema.Enum) {
+            console.log({ props, type, schema, parent });
+        }
 
         const slug = useMemo(() => slugify((parentSlug ? `${parentSlug}-` : '') + key), [parentSlug, key]);
         const fullLink = useMemo(() => {
@@ -124,16 +145,18 @@
         return html`
         <details class="collapse-panel" open="${isOpen}" onToggle=${e => { setIsOpen(e.target.open); e.stopPropagation(); }}>
             <summary class="collapse-header position-relative">
-                ${key} <kbd class="text-muted">${property.Type}</kbd> ${required ? html`<span class="badge badge-primary">required</span>` : ''}
+                ${key} <kbd class="text-muted">${type}</kbd> ${required ? html`<span class="badge badge-primary">required</span>` : ''}
                 <button class="btn btn-sm position-absolute right-0 top-0 m-5 copy-url z-10" type="button" data-clipboard-text="${fullLink}">🔗</button>
             </summary>
             <div id="${slug}" class="collapse-content">
                 ${React.createElement("div", { dangerouslySetInnerHTML: { __html: getDescription(property) } })}
                 ${propKeys.length > 0 ? html`<br />` : ''}
+                <div class="collapse-group">
                 ${propKeys
                 .map(propKey => SchemaPart({
-                    parent: property, parentKey: key, key: propKey, property: props[propKey], parentSlug: slug
+                    parent: schema, parentKey: key, key: propKey, property: props[propKey], parentSlug: slug
                 }))}
+                </div>
             </div>
         </details>`;
     }

--- a/template/doc.html
+++ b/template/doc.html
@@ -48,13 +48,17 @@
     if (properties.metadata && properties.metadata.Type == "object") delete properties.metadata;
 
     function getDescription(schema) {
-        let desc = schema.Description;
+        let desc = schema.Description || '';
         if (schema.Enum) {
             desc += '\n' + `
 \`\`\`yaml
 # valid values
 ${schema.Enum.map(e => `- '${e}'`).join('\n')}
 \`\`\``.trim()
+        }
+
+        if (desc.trim() == '') {
+            desc = '_No Description Provided._'
         }
         return DOMPurify.sanitize(marked(desc));
     }

--- a/template/doc.html
+++ b/template/doc.html
@@ -95,8 +95,10 @@ ${schema.Enum.map(e => `- '${e}'`).join('\n')}
                 if (itemsSchema.Type !== 'object') {
                     type = `[]${itemsSchema.Type}`;
                 } else {
+                    console.log({ property, itemsSchema });
                     schema = itemsSchema;
                     props = itemsSchema.Properties;
+                    type = `[]object`;
                 }
             }
             let propKeys = Object.keys(props);

--- a/template/doc.html
+++ b/template/doc.html
@@ -152,7 +152,7 @@ ${schema.Enum.map(e => `- '${e}'`).join('\n')}
                 <button class="btn btn-sm position-absolute right-0 top-0 m-5 copy-url z-10" type="button" data-clipboard-text="${fullLink}">🔗</button>
             </summary>
             <div id="${slug}" class="collapse-content">
-                ${React.createElement("div", { dangerouslySetInnerHTML: { __html: getDescription(property) } })}
+                ${React.createElement("div", { className: 'property-description', dangerouslySetInnerHTML: { __html: getDescription(property) } })}
                 ${propKeys.length > 0 ? html`<br />` : ''}
                 <div class="collapse-group">
                 ${propKeys
@@ -177,3 +177,9 @@ ${schema.Enum.map(e => `- '${e}'`).join('\n')}
 </script>
 <script defer src="https://unpkg.com/prismjs@1/components/prism-core.min.js"></script>
 <script defer src="https://unpkg.com/prismjs@1/plugins/autoloader/prism-autoloader.min.js"></script>
+<style>
+    /* Remove extra whitespace introduced by markdown translation */
+    .property-description > p {
+        margin: 0;
+    }
+</style>

--- a/template/doc.html
+++ b/template/doc.html
@@ -35,7 +35,8 @@
 
     marked.setOptions({
         highlight: (code, lang) => {
-            return `<pre><code class="language-${lang}">${code}</code></pre>`
+            // Handle the case where Prism might not have loaded yet.
+            return window.Prism ? Prism.highlight(code, Prism.languages[lang], lang) : `<pre><code class="language-${lang}">${code}</code></pre>`;
         }
     })
 
@@ -106,10 +107,6 @@ ${schema.Enum.map(e => `- '${e}'`).join('\n')}
             }
             return [props, propKeys, required, type, schema]
         }, [parent, property]);
-
-        if (schema.Enum) {
-            console.log({ props, type, schema, parent });
-        }
 
         const slug = useMemo(() => slugify((parentSlug ? `${parentSlug}-` : '') + key), [parentSlug, key]);
         const fullLink = useMemo(() => {

--- a/template/doc.html
+++ b/template/doc.html
@@ -33,10 +33,12 @@
         })
     });
 
-    marked.setOptions({
-        highlight: (code, lang) => {
-            // Handle the case where Prism might not have loaded yet.
-            return window.Prism ? Prism.highlight(code, Prism.languages[lang], lang) : `<pre><code class="language-${lang}">${code}</code></pre>`;
+    marked.use({
+        renderer: {
+            code: (code, lang, escaped) => {
+                const tokenizedCode = window.Prism ? Prism.highlight(code, Prism.languages[lang], lang) : `${code}`;
+                return `<pre class="language-${lang}"><code class="language-${lang}">${tokenizedCode}</code></pre>`;
+            }
         }
     })
 
@@ -49,14 +51,6 @@
 
     function getDescription(schema) {
         let desc = schema.Description || '';
-        if (schema.Enum) {
-            desc += '\n' + `
-\`\`\`yaml
-# valid values
-${schema.Enum.map(e => `- '${e}'`).join('\n')}
-\`\`\``.trim()
-        }
-
         if (desc.trim() == '') {
             desc = '_No Description Provided._'
         }

--- a/template/new.html
+++ b/template/new.html
@@ -1,4 +1,4 @@
-<div class="content-wrapper"></div>
+<div class="content-wrapper">
     <div class="container">
         <h2>Oops! Looks like we haven't indexed this repo yet. Feel free to <a
                 href="https://github.com/crdsdev/doc/issues/new">open an issue</a> and let us know you would like


### PR DESCRIPTION
Fixes a number of small render bugs:

- Array properties now will either display the primitive type (e.g. `[]string`) or the correct sub-properties.
- Adding some padding to the bottom of the page.
- Fixed an issue where the text of the new provider page was smushed into the nav bar.

Closes #102 