### PR TITLE
Read repositories from comma separated multiline

### DIFF
--- a/cmd/gitter/main.go
+++ b/cmd/gitter/main.go
@@ -51,7 +51,14 @@ var (
 func init() {
 	address = os.Getenv(envAddress)
 
-	repos = strings.Split(os.Getenv(envRepos), ",")
+	repos = normalize(os.Getenv(envRepos))
+}
+
+func normalize(s string) []string {
+	s = strings.Replace(s, "\n", "", -1)
+	s = strings.TrimSpace(s)
+
+	return strings.Split(s, ",")
 }
 
 func main() {

--- a/deploy/config.yaml
+++ b/deploy/config.yaml
@@ -9,4 +9,19 @@ metadata:
   name: doc-repos
   namespace: crdsdev
 data:
-  repos: "crossplane/crossplane,crossplane/provider-gcp,crossplane/provider-aws,crossplane/provider-azure,crossplane/provider-alibaba,crossplane/provider-rook,crossplane-contrib/provider-helm,kubernetes-sigs/cluster-api,jetstack/cert-manager,schemahero/schemahero,projectcontour/contour,packethost/crossplane-provider-packet,kubernetes-sigs/cluster-api-provider-packet,crossplane/oam-kubernetes-runtime,kubernetes-sigs/security-profiles-operator"
+  repos: |
+    crossplane/crossplane,
+    crossplane/provider-alibaba,
+    crossplane/provider-aws,
+    crossplane/provider-azure,
+    crossplane/provider-gcp,
+    crossplane/provider-rook,
+    crossplane/oam-kubernetes-runtime,
+    crossplane-contrib/provider-helm,
+    jetstack/cert-manager,
+    kubernetes-sigs/cluster-api,
+    kubernetes-sigs/cluster-api-provider-packet,
+    kubernetes-sigs/security-profiles-operator,
+    packethost/crossplane-provider-packet,
+    projectcontour/contour,
+    schemahero/schemahero


### PR DESCRIPTION
For better contributor experience and also maintainers to glance through
list of added repositories, converted from mandatory oneliner to more
readable multiline format. Also since this list potentially can grow in
size alphabetically ordered items for more predicatble insersion and
look up in the future.

Signed-off-by: Khosrow Moossavi <khos2ow@gmail.com>