### PR TITLE
Update instructions to serving latest tag if none specified

### DIFF
--- a/template/home.html
+++ b/template/home.html
@@ -9,7 +9,7 @@
             <div id="repo_go"></div>
             <p class="text-center">doc.crds.dev is and always will be <a href="https://github.com/crdsdev/doc">free and open source</a>.</p>
         </div>
-        <p>To find a repo, search <kbd>github.com/{org}/{repo}</kbd>. You may optionally append <kbd>@{version}</kbd> to view documentation for a specific version of the project. For example: <a href="/github.com/crossplane/crossplane@v0.10.0">github.com/crossplane/crossplane@v0.10.0</a>. If you do not include a tag, the latest from <kbd>master</kbd> will be served.</p>
+        <p>To find a repo, search <kbd>github.com/{org}/{repo}</kbd>. You may optionally append <kbd>@{version}</kbd> to view documentation for a specific version of the project. For example: <a href="/github.com/crossplane/crossplane@v0.10.0">github.com/crossplane/crossplane@v0.10.0</a>. If you do not include a tag, the latest indexed tag will be served.</p>
     </div>
 </div>
 


### PR DESCRIPTION
Doc no longer serves non-tagged versions of repositories. If a user does
not provide a tag the latest indexed tag will be served.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>