### PR TITLE
Provide more informative page titles

### DIFF
--- a/template/_head.html
+++ b/template/_head.html
@@ -16,7 +16,7 @@
 <meta name="twitter:image:src" content="https://doc.crds.dev/static/twitter.jpg" />
 <meta name="twitter:site" content="@crdsdev" />
 <meta name="twitter:card" content="summary" />
-<meta name="twitter:title" content="Doc" />
+<meta name="twitter:title" content="{{ .Page.Title }}" />
 <meta name="twitter:description" content="Automatic documentation for your CustomResourceDefinitions." />
 
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5.15.1/css/all.css" integrity="sha256-iqohlDG+xn9MRt53DKygzaORvtzhTCN4xvi1LHNU3OM=" crossorigin="anonymous">

--- a/template/layout.html
+++ b/template/layout.html
@@ -2,7 +2,7 @@
 <html>
 
 <head>
-    <title>Doc</title>
+    <title>{{ .Page.Title }}</title>
     {{ template "_head" . }}
     <link rel="stylesheet" href="/static/root.css">
 </head>


### PR DESCRIPTION
Updates org and doc pages to show more informative page titles and
twitter card information.

Fixes #128 

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>