### PR TITLE
Lowercase the hostname from the homepage

### DIFF
--- a/template/home.html
+++ b/template/home.html
@@ -24,7 +24,9 @@
         const input = useRef(null);
 
         const onSubmit = e => {
-            window.location.assign(`/${url}`);
+            const urlParts = url.split("/");
+            urlParts[0] = urlParts[0].toLowerCase();
+            window.location.assign(`/${urlParts.join("/")}`);
             e.preventDefault();
         };
 


### PR DESCRIPTION
Fixes #132. This makes the site a little easier to use in Safari where it auto corrects "github.com" to "GitHub.com" constantly, resulting in an error.

There are definitely better solutions, including an option to handle this in the backend api by removing the hard coded "github.com" from the handler and making it a variable. I'm guessing that there's a reason and plans to add support for non-github.com urls also though.

If the approach in this PR isn't agreeable, I'm happy to change it and implement the fix in the API instead.