### PR TITLE
fix: blank page with empty spec

### DIFF
--- a/template/doc.html
+++ b/template/doc.html
@@ -77,15 +77,14 @@
                 <button class="btn" type="button" onClick=${collapseAll}>- collapse all</button>
             </div>
             <div class="collapse-group">
-                ${
-                    properties != null 
-                    ? Object.keys(properties).map(prop => SchemaPart({ key: prop, property: properties[prop] }))
-                    : html`
+                ${properties != null
+                ? Object.keys(properties).map(prop => SchemaPart({ key: prop, property: properties[prop] }))
+                : html`
                     <p class="font-size-18">
                         This CRD has an empty or unspecified schema.
                     </p>
                     `
-                }
+            }
             </div>
         `;
     }
@@ -181,7 +180,7 @@
 <script defer src="https://unpkg.com/prismjs@1/plugins/autoloader/prism-autoloader.min.js"></script>
 <style>
     /* Remove extra whitespace introduced by markdown translation */
-    .property-description > p {
+    .property-description>p {
         margin: 0;
     }
 </style>

--- a/template/doc.html
+++ b/template/doc.html
@@ -45,9 +45,9 @@
     const { Kind, Group, Version, Schema } = JSON.parse(document.getElementById('pageData').textContent);
 
     const properties = Schema.Properties;
-    if (properties.apiVersion) delete properties.apiVersion;
-    if (properties.kind) delete properties.kind;
-    if (properties.metadata && properties.metadata.Type == "object") delete properties.metadata;
+    if (properties?.apiVersion) delete properties.apiVersion;
+    if (properties?.kind) delete properties.kind;
+    if (properties?.metadata?.Type == "object") delete properties.metadata;
 
     function getDescription(schema) {
         let desc = schema.Description || '';
@@ -72,12 +72,20 @@
 
             <p class="font-size-18">${React.createElement('div', { dangerouslySetInnerHTML: { __html: getDescription(Schema) } })}</p>
 
-            <div class="d-flex flex-row-reverse mb-10 mt-10">
+            <div class="${properties == null ? 'd-none' : 'd-flex'} flex-row-reverse mb-10 mt-10">
                 <button class="btn ml-10" type="button" onClick=${expandAll}>+ expand all</button>
                 <button class="btn" type="button" onClick=${collapseAll}>- collapse all</button>
             </div>
             <div class="collapse-group">
-            ${Object.keys(properties).map(prop => SchemaPart({ key: prop, property: properties[prop] }))}
+                ${
+                    properties != null 
+                    ? Object.keys(properties).map(prop => SchemaPart({ key: prop, property: properties[prop] }))
+                    : html`
+                    <p class="font-size-18">
+                        This CRD has an empty or unspecified schema.
+                    </p>
+                    `
+                }
             </div>
         `;
     }


### PR DESCRIPTION
Fixes an issue where the CRD page wouldn't render if the properties or spec was missing.

![image](https://user-images.githubusercontent.com/2391878/115621719-87c02500-a2bc-11eb-9a3f-ddd10517dc04.png)
