### PR TITLE
Strip protocol from urls

### DIFF
--- a/template/home.html
+++ b/template/home.html
@@ -24,7 +24,9 @@
         const input = useRef(null);
 
         const onSubmit = e => {
-            const urlParts = url.split("/");
+            const urlParts = url
+                .replace(/https?:\/\//, "")
+                .split("/");
             urlParts[0] = urlParts[0].toLowerCase();
             window.location.assign(`/${urlParts.join("/")}`);
             e.preventDefault();


### PR DESCRIPTION
Strips the `http(s)://` protocol from URLs entered into the input box on the home page, which allows to copy/paste urls more conveniently.