### PR TITLE
Quick fix for null itemsSchema property

### DIFF
--- a/template/doc.html
+++ b/template/doc.html
@@ -100,7 +100,6 @@
                 if (itemsSchema.Type !== 'object') {
                     type = `[]${itemsSchema.Type}`;
                 } else {
-                    console.log({ property, itemsSchema });
                     schema = itemsSchema;
                     props = itemsSchema.Properties || {};
                     type = `[]object`;

--- a/template/doc.html
+++ b/template/doc.html
@@ -102,7 +102,7 @@
                 } else {
                     console.log({ property, itemsSchema });
                     schema = itemsSchema;
-                    props = itemsSchema.Properties;
+                    props = itemsSchema.Properties || {};
                     type = `[]object`;
                 }
             }


### PR DESCRIPTION
This updates the parsing of itemsSchema property to default to empty
object in the event it is null. We should be parsing down into
additionalProperties to provide more information, but this at least gets
us rendering correctly.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Fixes #157 

Tested CRD in question locally:
![Screenshot from 2021-12-20 11-16-29](https://user-images.githubusercontent.com/31777345/146798867-d6d11dbb-0f2f-437a-87d5-61608e2fafa7.png)
