### PR TITLE
Better onboarding

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -81,13 +81,13 @@ Then we start the doc server properly
 docker run -d --rm \
    -p 5000:5000 \
    --link dev-postgres:pg \
-   --link doc-gitter:gitter \
+   --link doc-gitter:gt \
    -e PG_USER=postgres \
    -e PG_PASS=password \
    -e PG_HOST=pg \
    -e PG_PORT=5432 \
    -e PG_DB=doc \
-   -e GITTER_HOST=gitter \
+   -e GITTER_HOST=gt \
    crdsdev/doc:latest
 ```
 And you should be able to browse the server by hitting `http://localhost:5000`.

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,5 +1,7 @@
 # Developing
 
+# Launch Database
+
 ## Using Postgres Docker Image
 
 The easiest way to get started developing locally is with the official [Postgres
@@ -16,11 +18,17 @@ docker run -d --rm \
 
 2. Setup doc database and tables:
 
-```
-psql -h 127.0.0.1 -U postgres -d postgres -a -f schema/crds_up.sql
-```
+   1. Either using Docker:
+   ```
+   docker exec -i dev-postgres psql -U postgres < schema/crds_up.sql
+   ```
 
-## Using CloudSQL Proxy
+   2. Or with native psql:
+   ```
+   psql -h 127.0.0.1 -U postgres -d postgres -a -f schema/crds_up.sql
+   ```
+
+### Using CloudSQL Proxy
 
 If using [CloudSQL](https://cloud.google.com/sql) for a hosted Postgres
 solution, the following steps can be used to develop locally against your
@@ -52,3 +60,34 @@ docker run -d \
 ```
 psql -h 127.0.0.1 -U postgres -d postgres -a -f schema/crds_up.sql
 ```
+
+# Start Doc server
+
+First we need to start the worker to fetch the content. The code below assumes you deployed using a PostgreSQL Docker image.
+```
+docker run -d --rm \
+   -p 1234:1234 \
+   --link dev-postgres:pg \
+   -e PG_USER=postgres \
+   -e PG_PASS=password \
+   -e PG_HOST=pg \
+   -e PG_PORT=5432 \
+   -e PG_DB=doc \
+   crdsdev/doc-gitter:latest
+```
+
+Then we start the doc server properly
+```
+docker run -d --rm \
+   -p 5000:5000 \
+   --link dev-postgres:pg \
+   --link doc-gitter:gitter \
+   -e PG_USER=postgres \
+   -e PG_PASS=password \
+   -e PG_HOST=pg \
+   -e PG_PORT=5432 \
+   -e PG_DB=doc \
+   -e GITTER_HOST=gitter \
+   crdsdev/doc:latest
+```
+And you should be able to browse the server by hitting `http://localhost:5000`.

--- a/cmd/doc/main.go
+++ b/cmd/doc/main.go
@@ -54,6 +54,11 @@ var (
 	portEnv     = "PG_PORT"
 	dbEnv       = "PG_DB"
 
+	gitterHostEnv     = "GITTER_HOST"
+	gitterPortEnv     = "GITTER_PORT"
+	gitterHostDefault = "127.0.0.1"
+	gitterPortDefault = "1234"
+
 	cookieDarkMode = "halfmoon_preferredMode"
 
 	address   string
@@ -125,7 +130,15 @@ type homeData struct {
 
 func worker(gitterChan <-chan models.GitterRepo) {
 	for job := range gitterChan {
-		client, err := rpc.DialHTTP("tcp", "127.0.0.1:1234")
+		var gitterHost, gitterPort string
+		var envVarExists bool
+		if gitterHost, envVarExists = os.LookupEnv(gitterHostEnv); !envVarExists {
+			gitterHost = gitterHostDefault
+		}
+		if gitterPort, envVarExists = os.LookupEnv(gitterPortEnv); !envVarExists {
+			gitterPort = gitterPortDefault
+		}
+		client, err := rpc.DialHTTP("tcp", fmt.Sprintf("%s:%s", gitterHost, gitterPort))
 		if err != nil {
 			log.Fatal("dialing:", err)
 		}

--- a/deploy/doc.Dockerfile
+++ b/deploy/doc.Dockerfile
@@ -3,14 +3,18 @@
 # https://hub.docker.com/_/golang
 FROM golang:1.13 as builder
 
-WORKDIR app/
+WORKDIR /go/app/
+
+# Copy and cache dependencies
+COPY ../go.mod .
+COPY ../go.sum .
+
+# Retrieve application dependencies.
+# This allows the container build to reuse cached dependencies as long as go.mod and go.sum are unchanged.
+RUN go mod download
 
 # Copy internal libraries.
 COPY . .
-
-# Retrieve application dependencies.
-# This allows the container build to reuse cached dependencies.
-RUN go mod download
 
 # Build the binary.
 RUN CGO_ENABLED=0 GOOS=linux go build -o doc -mod=readonly -v ./cmd/doc/main.go
@@ -22,7 +26,7 @@ FROM alpine:3
 RUN apk add --no-cache ca-certificates
 
 # Copy the binary to the production image from the builder stage.
-COPY --from=builder go/app/doc ./
+COPY --from=builder /go/app/doc ./
 COPY ./template ./template
 COPY ./static ./static
 


### PR DESCRIPTION
* explains how to use PostgreSQL image and launch Doc images
* optionally exposing Gitter host/port so it can be used locally with Docker
* improved Dockerfile by allowing cache of Go dependencies (by moving copy of go.sum and go.mod before `go mod download`)