### PR TITLE
Use production jsDelivr URL

### DIFF
--- a/template/org.html
+++ b/template/org.html
@@ -31,7 +31,7 @@
   </script>
 <script src="https://unpkg.com/react-table@7/dist/react-table.production.min.js"></script>
 <script type="module">
-    import { formatRelative } from 'https://esm.run/date-fns';
+    import { formatRelative } from 'https://cdn.jsdelivr.net/npm/date-fns/+esm';
 
     const { render } = ReactDOM;
     const { html } = htmReact;


### PR DESCRIPTION
According to the note at the bottom of https://esm.run, the production URL to be used should use their main domain at https://cdn.jsdelivr.net/