### PR TITLE
Pin eventemitter3 to 4.0.7

### DIFF
--- a/template/doc.html
+++ b/template/doc.html
@@ -12,7 +12,7 @@
 {{ template "_scripts" . }}
 <script src="https://unpkg.com/marked@1.2.4/marked.min.js"></script>
 <script src="https://unpkg.com/dompurify@2.2.2/dist/purify.js"></script>
-<script src="https://unpkg.com/eventemitter3@latest/umd/eventemitter3.min.js"></script>
+<script src="https://unpkg.com/eventemitter3@4.0.7/umd/eventemitter3.min.js"></script>
 <script src="https://unpkg.com/slugify@1.4.6/slugify.js"></script>
 <script src="https://unpkg.com/clipboard@2.0.6/dist/clipboard.min.js"></script>
 <script id="pageData" type="application/json">


### PR DESCRIPTION
Pins eventemitter3 to 4.0.7 as 5.0.0 is a breaking change.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Fixes #167 