### PR TITLE
feat(issue-16): Add private Repo support

### DIFF
--- a/cmd/doc/main.go
+++ b/cmd/doc/main.go
@@ -30,6 +30,7 @@ import (
 
 	crdutil "github.com/crdsdev/doc/pkg/crd"
 	"github.com/crdsdev/doc/pkg/models"
+	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -44,6 +45,7 @@ var db *pgxpool.Pool
 
 // redis connection
 var (
+	envAnalytics   = "ANALYTICS"
 	envDevelopment = "IS_DEV"
 
 	userEnv     = "PG_USER"
@@ -53,6 +55,9 @@ var (
 	dbEnv       = "PG_DB"
 
 	cookieDarkMode = "halfmoon_preferredMode"
+
+	address   string
+	analytics bool = false
 
 	gitterChan chan models.GitterRepo
 )
@@ -81,6 +86,7 @@ var page = render.New(render.Options{
 })
 
 type pageData struct {
+	Analytics     bool
 	DisableNavBar bool
 	IsDarkMode    bool
 	Title         string
@@ -141,6 +147,12 @@ func tryIndex(repo models.GitterRepo, gitterChan chan models.GitterRepo) bool {
 }
 
 func init() {
+	// TODO(hasheddan): use a flag
+	analyticsStr := os.Getenv(envAnalytics)
+	if analyticsStr == "true" {
+		analytics = true
+	}
+
 	gitterChan = make(chan models.GitterRepo, 4)
 }
 
@@ -169,6 +181,7 @@ func getPageData(r *http.Request, title string, disableNavBar bool) pageData {
 		isDarkMode = true
 	}
 	return pageData{
+		Analytics:     analytics,
 		IsDarkMode:    isDarkMode,
 		DisableNavBar: disableNavBar,
 		Title:         title,
@@ -244,6 +257,31 @@ func raw(w http.ResponseWriter, r *http.Request) {
 	} else {
 		w.Write([]byte(total))
 		log.Printf("successfully rendered raw CRDs")
+	}
+
+	if analytics {
+		u := uuid.New().String()
+		// TODO(hasheddan): do not hardcode tid and dh
+		metrics := url.Values{
+			"v":   {"1"},
+			"t":   {"pageview"},
+			"tid": {"UA-116820283-2"},
+			"cid": {u},
+			"dh":  {"doc.crds.dev"},
+			"dp":  {r.URL.Path},
+			"uip": {r.RemoteAddr},
+		}
+		client := &http.Client{}
+
+		req, _ := http.NewRequest("POST", "http://www.google-analytics.com/collect", strings.NewReader(metrics.Encode()))
+		req.Header.Add("User-Agent", r.UserAgent())
+		req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+		if _, err := client.Do(req); err != nil {
+			log.Printf("failed to report analytics: %s", err.Error())
+		} else {
+			log.Printf("successfully reported analytics")
+		}
 	}
 }
 

--- a/cmd/doc/main.go
+++ b/cmd/doc/main.go
@@ -126,7 +126,7 @@ type homeData struct {
 
 func worker(gitterChan <-chan models.GitterRepo) {
 	for job := range gitterChan {
-		client, err := rpc.DialHTTP("tcp", "gitter:1234")
+		client, err := rpc.DialHTTP("tcp", "127.0.0.1:1234")
 		if err != nil {
 			log.Fatal("dialing:", err)
 		}

--- a/deploy/gitter.yaml
+++ b/deploy/gitter.yaml
@@ -15,6 +15,9 @@ spec:
           containers:
           - name: gitter
             image: crdsdev/doc-gitter:latest
+            volumeMounts:
+              - name: repo-config
+                mountPath: usr
             env:
             - name: REDIS_HOST
               valueFrom:
@@ -26,4 +29,24 @@ spec:
                 configMapKeyRef:
                   name: doc-repos
                   key: repos
+          volumes:
+            - name: repo-config
+              configMap:
+                name: private-repos-auth
+
           restartPolicy: Never
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: private-repos-auth
+  namespace: crdsdev
+data:
+  # Add authentication details for private Github repos and servers as shown in the example entry
+  repos.yaml: |-
+    repos:
+     - name: owner/private-repository
+       server: github.mycompany.com
+       user:
+         name: machineuser
+         pwdFromEnv: MACHINE_SECRET

--- a/pkg/models/repo.go
+++ b/pkg/models/repo.go
@@ -28,7 +28,8 @@ type RepoCRD struct {
 
 // GitterRepo is the repo for gitter to index.
 type GitterRepo struct {
-	Org  string
-	Repo string
-	Tag  string
+	Server string
+	Org    string
+	Repo   string
+	Tag    string
 }

--- a/template/_head.html
+++ b/template/_head.html
@@ -1,14 +1,4 @@
 <link rel="icon" type="image/png" href="/static/favicon.ico?v=1" />
-{{ if .Page.Analytics }}
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-116820283-2"></script>
-<script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag() { dataLayer.push(arguments); }
-    gtag('js', new Date());
-
-    gtag('config', 'UA-116820283-2');
-</script>
-{{ end }}
 <meta charset="utf-8" />
 <meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" name="viewport" />
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/template/_head.html
+++ b/template/_head.html
@@ -1,4 +1,14 @@
 <link rel="icon" type="image/png" href="/static/favicon.ico?v=1" />
+{{ if .Page.Analytics }}
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-116820283-2"></script>
+<script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag() { dataLayer.push(arguments); }
+    gtag('js', new Date());
+
+    gtag('config', 'UA-116820283-2');
+</script>
+{{ end }}
 <meta charset="utf-8" />
 <meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" name="viewport" />
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/template/org.html
+++ b/template/org.html
@@ -1,19 +1,19 @@
 <div class="content-wrapper">
     <div class="container">
         <div class="content">
-            <h1><a href="/github.com/{{ .Repo }}@{{ .Tag }}">{{ .Repo }}@{{ .Tag }}</a></h1>
+            <h1><a href="/{{ .Server }}/{{ .Repo }}@{{ .Tag }}">{{ .Repo }}@{{ .Tag }}</a></h1>
             {{ if .Tag }}
-                <a href="https://github.com/{{ .Repo }}/tree/{{ .Tag }}"><span class="label label-primary">github.com/{{ .Repo }}/tree/{{ .Tag }}</span></a>
+                <a href="https://{{ .Server }}/{{ .Repo }}/tree/{{ .Tag }}"><span class="label label-primary">{{ .Server }}/{{ .Repo }}/tree/{{ .Tag }}</span></a>
             {{ else }}
-                <a href="https://github.com/{{ .Repo }}/tree/master"><span class="label label-primary">github.com/{{ .Repo }}/tree/master</span></a>
+                <a href="https://{{ .Server }}/{{ .Repo }}/tree/master"><span class="label label-primary">{{ .Server }}/{{ .Repo }}/tree/master</span></a>
             {{ end }}
         </div>
         <select class="form-control w-md-400 w-sm-full mb-md-10 mb-5" onchange="handleSelect(this)">
-            {{ $actual := .Tag }}{{ $repo := .Repo }}{{ range $name := .Tags }}
+            {{ $actual := .Tag }}{{ $server := .Server }}{{ $repo := .Repo }}{{ range $name := .Tags }}
                 {{ if eq $name $actual }}
-                <option value="/github.com/{{ $repo }}@{{ $name }}" selected="selected">{{ $name }}</option>
+                <option value="/{{ $server }}/{{ $repo }}@{{ $name }}" selected="selected">{{ $name }}</option>
                 {{ else }}
-                <option value="/github.com/{{ $repo }}@{{ $name }}" >{{ $name }}</option>
+                <option value="/{{ $server }}/{{ $repo }}@{{ $name }}" >{{ $name }}</option>
                 {{ end }}
             {{ end }}
           </select>
@@ -37,14 +37,14 @@
     const { html } = htmReact;
     const { useTable, useSortBy, useGlobalFilter  } = ReactTable;
 
-    const { Repo, CRDs, Tag, At, } = JSON.parse(`{{ . }}`);
+    const { Server, Repo, CRDs, Tag, At, } = JSON.parse(`{{ . }}`);
     const data = Object.keys(CRDs).map(key => CRDs[key]);
 
     const columns = [
         {
             Header: 'Kind',
             accessor: 'Kind',
-            Cell: ({ row: { original }, value }) => html`<a href=${`/github.com/${Repo}/${original.Group}/${original.Kind}/${original.Version}@${Tag}`}>${value}</a>`
+            Cell: ({ row: { original }, value }) => html`<a href=${`/${Server}/${Repo}/${original.Group}/${original.Kind}/${original.Version}@${Tag}`}>${value}</a>`
         },
         {
             Header: 'Group',


### PR DESCRIPTION
This PR adds support for private repositories and self-hosted Github servers.
They can be added to the config.yaml as documented in the repository.
Note that this setup works when hosting, for local execution the config must be placed in the respective folder.

@hasheddan 